### PR TITLE
feat: finalizado menu de Participações com cards e visual mobile (simulador)

### DIFF
--- a/application/config/migration.php
+++ b/application/config/migration.php
@@ -69,7 +69,7 @@ $config['migration_auto_latest'] = FALSE;
 | be upgraded / downgraded to.
 |
 */
-$config['migration_version'] = 20250702140000;
+$config['migration_version'] = 20250702160000;
 
 /*
 |--------------------------------------------------------------------------

--- a/application/controllers/Campanhas.php
+++ b/application/controllers/Campanhas.php
@@ -33,6 +33,7 @@ class Campanhas extends CI_Controller {
         $this->form_validation->set_rules('data_fim', 'Data de Fim', 'required|callback_validar_data');
         $this->form_validation->set_rules('recorrencia', 'Recorrência', 'required');
         $this->form_validation->set_rules('gasto', 'Gasto', 'required|numeric|greater_than_equal_to[0]');
+        $this->form_validation->set_rules('premio', 'Prêmio', 'required|numeric|greater_than_equal_to[0]');
 
         // AIDEV-TODO: Implementar validação de datas e recorrência mais robusta
 
@@ -46,6 +47,7 @@ class Campanhas extends CI_Controller {
                 'data_fim' => $this->input->post('data_fim'),
                 'recorrencia' => $this->input->post('recorrencia'),
                 'gasto' => $this->input->post('gasto'),
+                'premio' => $this->input->post('premio'),
                 'status' => 1 // Ativa por padrão ao criar
             );
 
@@ -75,6 +77,7 @@ class Campanhas extends CI_Controller {
         $this->form_validation->set_rules('data_fim', 'Data de Fim', 'required|callback_validar_data');
         $this->form_validation->set_rules('recorrencia', 'Recorrência', 'required');
         $this->form_validation->set_rules('gasto', 'Gasto', 'required|numeric|greater_than_equal_to[0]');
+        $this->form_validation->set_rules('premio', 'Prêmio', 'required|numeric|greater_than_equal_to[0]');
 
         // AIDEV-TODO: Implementar validação de datas e recorrência mais robusta
 
@@ -87,7 +90,8 @@ class Campanhas extends CI_Controller {
                 'data_inicio' => $this->input->post('data_inicio'),
                 'data_fim' => $this->input->post('data_fim'),
                 'recorrencia' => $this->input->post('recorrencia'),
-                'gasto' => $this->input->post('gasto')
+                'gasto' => $this->input->post('gasto'),
+                'premio' => $this->input->post('premio')
             );
 
             $this->Campanhas_model->update($id, $data);

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -16,6 +16,11 @@ class Dashboard extends CI_Controller {
         $data['campanhas_ativas'] = $this->Campanhas_model->countActiveCampanhas();
         $data['novas_campanhas_semana'] = $this->Campanhas_model->countNewCampanhasThisWeek();
 
+        // AIDEV-GENERATED: Dados para o Campeão de Resgates
+        $nomes_funcionarios = ['João Silva', 'Maria Souza', 'Pedro Almeida', 'Ana Costa', 'Carlos Lima'];
+        $data['campeao_nome'] = $nomes_funcionarios[array_rand($nomes_funcionarios)];
+        $data['campeao_resgatado'] = rand(100, 500); // Valor aleatório entre 100 e 500
+
         $this->load->view('templates/header_view');
         $this->load->view('dashboard_view', $data);
         $this->load->view('templates/footer_view');

--- a/application/controllers/Participacoes.php
+++ b/application/controllers/Participacoes.php
@@ -1,0 +1,76 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Participacoes extends CI_Controller {
+
+    public function __construct() {
+        parent::__construct();
+        $this->load->model('Participacao_model');
+        $this->load->model('Campanhas_model');
+        $this->load->model('Usuarios_model');
+        $this->load->helper('url');
+        $this->load->library('session');
+
+        // AIDEV-NOTE: Redireciona para login se o usuário não estiver logado
+        if (!$this->session->userdata('user_logged_in')) {
+            redirect('login');
+        }
+    }
+
+    // AIDEV-GENERATED: Exibe a lista de campanhas disponíveis para participação (simulando tela de celular)
+    public function index() {
+        $usuario_id = $this->session->userdata('user_id');
+        $data['campanhas_disponiveis'] = $this->Participacao_model->getAvailableCampanhasForUser($usuario_id);
+
+        // AIDEV-GENERATED: Dados para o Campeão de Resgates na tela de Participações
+        $nomes_funcionarios = ['João Silva', 'Maria Souza', 'Pedro Almeida', 'Ana Costa', 'Carlos Lima'];
+        $data['campeao_nome'] = $this->session->userdata('user_name');
+        $data['campeao_resgatado'] = rand(100, 500); // Valor aleatório entre 100 e 500
+        $data['current_user_name'] = $this->session->userdata('user_name');
+
+        $this->load->view('templates/header_view'); // Pode ser um header mais simples para mobile
+        $this->load->view('participacoes/mobile_campanhas', $data);
+        $this->load->view('templates/footer_view'); // Pode ser um footer mais simples para mobile
+    }
+
+    // AIDEV-GENERATED: Processa a participação em uma campanha
+    public function participar($campanha_id) {
+        $usuario_id = $this->session->userdata('user_id');
+
+        // Verifica se o usuário já participou desta campanha
+        if ($this->Participacao_model->hasParticipated($campanha_id, $usuario_id)) {
+            $this->session->set_flashdata('error', 'Você já está participando desta campanha.');
+        } else {
+            $data = array(
+                'campanha_id' => $campanha_id,
+                'usuario_id' => $usuario_id,
+                'data_participacao' => date('Y-m-d H:i:s'),
+                'status_participacao' => 'pendente' // Status inicial da participação
+            );
+
+            if ($this->Participacao_model->create($data)) {
+                $this->session->set_flashdata('success', 'Sua participação foi registrada com sucesso!');
+            } else {
+                $this->session->set_flashdata('error', 'Erro ao registrar sua participação. Tente novamente.');
+            }
+        }
+        redirect('participacoes'); // Redireciona de volta para a lista de campanhas
+    }
+
+    // AIDEV-GENERATED: Exibe a lista de todas as participações (para admin/supervisor)
+    public function listar_todas() {
+        // AIDEV-TODO: Implementar checagem de permissão para esta função
+        $data['participacoes'] = $this->Participacao_model->getAll();
+        $this->load->view('templates/header_view');
+        $this->load->view('participacoes/listar_todas', $data);
+        $this->load->view('templates/footer_view');
+    }
+
+    // AIDEV-GENERATED: Exibe campanhas ativas com detalhes de participação em formato de cards
+    public function ativas() {
+        $data['campanhas_ativas'] = $this->Participacao_model->getActiveCampaignsWithParticipationDetails();
+        $this->load->view('templates/header_view');
+        $this->load->view('participacoes/listar_ativas', $data);
+        $this->load->view('templates/footer_view');
+    }
+}

--- a/application/migrations/20250702150000_create_participacoes_table.php
+++ b/application/migrations/20250702150000_create_participacoes_table.php
@@ -1,0 +1,53 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Create_participacoes_table extends CI_Migration {
+
+    public function up() {
+        $this->dbforge->add_field(array(
+            'id' => array(
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => TRUE,
+                'auto_increment' => TRUE
+            ),
+            'campanha_id' => array(
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => TRUE,
+            ),
+            'usuario_id' => array(
+                'type' => 'INT',
+                'constraint' => 11,
+                'unsigned' => TRUE,
+            ),
+            'data_participacao' => array(
+                'type' => 'TIMESTAMP',
+                'null' => TRUE,
+            ),
+            'status_participacao' => array(
+                'type' => 'VARCHAR',
+                'constraint' => '50',
+                'default' => 'pendente',
+            ),
+            'created_at' => array(
+                'type' => 'TIMESTAMP',
+                'null' => TRUE,
+            ),
+            'updated_at' => array(
+                'type' => 'TIMESTAMP',
+                'null' => TRUE,
+            ),
+        ));
+        $this->dbforge->add_key('id', TRUE);
+        $this->dbforge->create_table('participacoes');
+
+        // Adicionar chaves estrangeiras (opcional, mas recomendado para integridade)
+        $this->db->query('ALTER TABLE `participacoes` ADD CONSTRAINT `fk_participacoes_campanhas` FOREIGN KEY (`campanha_id`) REFERENCES `campanhas`(`id`) ON DELETE CASCADE ON UPDATE CASCADE');
+        $this->db->query('ALTER TABLE `participacoes` ADD CONSTRAINT `fk_participacoes_usuarios` FOREIGN KEY (`usuario_id`) REFERENCES `usuarios`(`id`) ON DELETE CASCADE ON UPDATE CASCADE');
+    }
+
+    public function down() {
+        $this->dbforge->drop_table('participacoes');
+    }
+}

--- a/application/migrations/20250702160000_add_premio_to_campanhas.php
+++ b/application/migrations/20250702160000_add_premio_to_campanhas.php
@@ -1,0 +1,21 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Migration_Add_premio_to_campanhas extends CI_Migration {
+
+    public function up() {
+        $fields = array(
+            'premio' => array(
+                'type' => 'DECIMAL',
+                'constraint' => '10,2',
+                'default' => 0.00,
+                'null' => FALSE,
+            ),
+        );
+        $this->dbforge->add_column('campanhas', $fields);
+    }
+
+    public function down() {
+        $this->dbforge->drop_column('campanhas', 'premio');
+    }
+}

--- a/application/models/Participacao_model.php
+++ b/application/models/Participacao_model.php
@@ -1,0 +1,80 @@
+<?php
+defined('BASEPATH') OR exit('No direct script access allowed');
+
+class Participacao_model extends CI_Model {
+
+    public function __construct() {
+        parent::__construct();
+        $this->load->database();
+    }
+
+    // AIDEV-GENERATED: Método para criar uma nova participação
+    public function create($data) {
+        $data['data_participacao'] = date('Y-m-d H:i:s');
+        $data['created_at'] = date('Y-m-d H:i:s');
+        $data['updated_at'] = date('Y-m-d H:i:s');
+        return $this->db->insert('participacoes', $data);
+    }
+
+    // AIDEV-GENERATED: Método para obter todas as participações
+    public function getAll() {
+        $this->db->select('p.*, c.nome as campanha_nome, u.nome as usuario_nome');
+        $this->db->from('participacoes p');
+        $this->db->join('campanhas c', 'c.id = p.campanha_id', 'left');
+        $this->db->join('usuarios u', 'u.id = p.usuario_id', 'left');
+        return $this->db->get()->result();
+    }
+
+    // AIDEV-GENERATED: Método para obter uma participação por ID
+    public function getById($id) {
+        $this->db->select('p.*, c.nome as campanha_nome, u.nome as usuario_nome');
+        $this->db->from('participacoes p');
+        $this->db->join('campanhas c', 'c.id = p.campanha_id', 'left');
+        $this->db->join('usuarios u', 'u.id = p.usuario_id', 'left');
+        $this->db->where('p.id', $id);
+        return $this->db->get()->row();
+    }
+
+    // AIDEV-GENERATED: Método para atualizar uma participação existente
+    public function update($id, $data) {
+        $data['updated_at'] = date('Y-m-d H:i:s');
+        $this->db->where('id', $id);
+        return $this->db->update('participacoes', $data);
+    }
+
+    // AIDEV-GENERATED: Método para deletar uma participação
+    public function delete($id) {
+        $this->db->where('id', $id);
+        return $this->db->delete('participacoes');
+    }
+
+    // AIDEV-GENERATED: Método para verificar se um usuário já participou de uma campanha
+    public function hasParticipated($campanha_id, $usuario_id) {
+        $this->db->where('campanha_id', $campanha_id);
+        $this->db->where('usuario_id', $usuario_id);
+        $query = $this->db->get('participacoes');
+        return $query->num_rows() > 0;
+    }
+
+    // AIDEV-GENERATED: Método para obter campanhas ativas para participação (não participadas pelo usuário)
+    public function getAvailableCampanhasForUser($usuario_id) {
+        $this->db->select('c.*, c.premio, p.id as participacao_id');
+        $this->db->from('campanhas c');
+        $this->db->where('c.status', 1); // Apenas campanhas ativas
+        $this->db->where('c.data_fim >= CURDATE()'); // Apenas campanhas não expiradas
+        $this->db->join('participacoes p', 'p.campanha_id = c.id AND p.usuario_id = ' . $this->db->escape($usuario_id), 'left');
+        $this->db->where('p.id IS NULL'); // Onde não há participação para este usuário
+        return $this->db->get()->result();
+    }
+
+    // AIDEV-GENERATED: Método para obter campanhas ativas com detalhes de participação
+    public function getActiveCampaignsWithParticipationDetails() {
+        $this->db->select('c.*, COUNT(pa.id) as total_participantes, DATEDIFF(c.data_fim, CURDATE()) as dias_restantes');
+        $this->db->from('campanhas c');
+        $this->db->join('participacoes pa', 'pa.campanha_id = c.id', 'left');
+        $this->db->where('c.status', 1); // Apenas campanhas ativas
+        $this->db->group_by('c.id');
+        $this->db->order_by('c.data_fim', 'ASC');
+        return $this->db->get()->result();
+    }
+}

--- a/application/views/campanhas/criar.php
+++ b/application/views/campanhas/criar.php
@@ -39,6 +39,11 @@
             <input type="number" step="0.01" name="gasto" id="gasto" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="<?php echo set_value('gasto'); ?>">
         </div>
 
+        <div class="mb-4">
+            <label for="premio" class="block text-gray-700 text-sm font-bold mb-2">Prêmio:</label>
+            <input type="number" step="0.01" name="premio" id="premio" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="<?php echo set_value('premio'); ?>">
+        </div>
+
         <div class="flex items-center justify-between">
             <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
                 Salvar Campanha

--- a/application/views/campanhas/editar.php
+++ b/application/views/campanhas/editar.php
@@ -39,6 +39,11 @@
             <input type="number" step="0.01" name="gasto" id="gasto" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="<?php echo set_value('gasto', $campanha->gasto); ?>">
         </div>
 
+        <div class="mb-4">
+            <label for="premio" class="block text-gray-700 text-sm font-bold mb-2">Prêmio:</label>
+            <input type="number" step="0.01" name="premio" id="premio" class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" value="<?php echo set_value('premio', $campanha->premio); ?>">
+        </div>
+
         <div class="flex items-center justify-between">
             <button type="submit" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
                 Atualizar Campanha

--- a/application/views/campanhas/listar.php
+++ b/application/views/campanhas/listar.php
@@ -18,6 +18,7 @@
                         <th class="py-2 px-4 border-b">Data Fim</th>
                         <th class="py-2 px-4 border-b">Recorrência</th>
                         <th class="py-2 px-4 border-b">Gasto</th>
+                        <th class="py-2 px-4 border-b">Prêmio</th>
                         <th class="py-2 px-4 border-b">Status</th>
                         <th class="py-2 px-4 border-b">Ações</th>
                     </tr>
@@ -32,6 +33,7 @@
                             <td class="py-2 px-4 border-b text-center"><?php echo $campanha->data_fim; ?></td>
                             <td class="py-2 px-4 border-b text-center"><?php echo $campanha->recorrencia; ?></td>
                             <td class="py-2 px-4 border-b text-center"><?php echo number_format($campanha->gasto, 2, ',', '.'); ?></td>
+                            <td class="py-2 px-4 border-b text-center">R$ <?php echo number_format($campanha->premio, 2, ',', '.'); ?></td>
                             <td class="py-2 px-4 border-b text-center">
                                 <?php if ($campanha->status == 1): ?>
                                     <span class="bg-green-200 text-green-800 text-xs font-medium px-2.5 py-0.5 rounded-full">Ativa</span>

--- a/application/views/dashboard_view.php
+++ b/application/views/dashboard_view.php
@@ -1,6 +1,18 @@
 <h1 class="text-3xl font-bold text-gray-800 mb-6 flex items-center"><i class="fas fa-tachometer-alt mr-3"></i> Dashboard</h1>
 
 <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
+    <!-- Card Campeão de Resgates -->
+    <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-yellow-500">
+        <div class="flex items-center justify-between mb-4">
+            <h2 class="text-lg font-semibold text-gray-700">🏆 Campeão de Resgates</h2>
+            <div class="text-yellow-500 text-2xl"><i class="fas fa-trophy"></i></div>
+        </div>
+        <p class="text-xl font-bold text-gray-900">Funcionário: <?php echo $campeao_nome; ?></p>
+        <p class="text-xl font-bold text-gray-900 mb-2">Total Resgatado: R$ <?php echo number_format($campeao_resgatado, 2, ',', '.'); ?></p>
+        <p class="text-sm text-gray-600">Parabéns, <?php echo $campeao_nome; ?>! Você é o destaque do mês!</p>
+        <p class="text-sm text-gray-500">Continue participando das campanhas e você pode ser o próximo campeão!</p>
+    </div>
+
     <!-- Card 1 -->
     <div class="bg-white rounded-lg shadow-md p-6">
         <div class="flex items-center justify-between mb-4">

--- a/application/views/participacoes/listar_ativas.php
+++ b/application/views/participacoes/listar_ativas.php
@@ -1,0 +1,29 @@
+<div class="container mx-auto p-4">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6 flex items-center"><i class="fas fa-list-alt mr-3"></i> Campanhas Ativas</h1>
+
+    <?php if (empty($campanhas_ativas)): ?>
+        <p>Nenhuma campanha ativa encontrada.</p>
+    <?php else: ?>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            <?php foreach ($campanhas_ativas as $campanha): ?>
+                <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-blue-500">
+                    <h2 class="text-xl font-bold text-gray-800 mb-2">🏆 <?php echo $campanha->nome; ?></h2>
+                    <p class="text-gray-600 mb-2"><?php echo $campanha->descricao; ?></p>
+                    <p class="text-sm text-gray-500">Prêmio: R$ <?php echo number_format($campanha->premio, 2, ',', '.'); ?></p>
+                    <p class="text-sm text-gray-500">Participantes: <?php echo $campanha->total_participantes; ?></p>
+                    <p class="text-sm font-semibold <?php echo ($campanha->dias_restantes <= 7 && $campanha->dias_restantes >= 0) ? 'text-red-500' : 'text-gray-500'; ?>">
+                        <?php 
+                            if ($campanha->dias_restantes > 0) {
+                                echo '⏳ Faltam ' . $campanha->dias_restantes . ' dias';
+                            } elseif ($campanha->dias_restantes == 0) {
+                                echo '⏰ Último dia!';
+                            } else {
+                                echo '✅ Encerrada';
+                            }
+                        ?>
+                    </p>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+</div>

--- a/application/views/participacoes/listar_todas.php
+++ b/application/views/participacoes/listar_todas.php
@@ -1,0 +1,37 @@
+<div class="container mx-auto p-4">
+    <h1 class="text-3xl font-bold text-gray-800 mb-6 flex items-center"><i class="fas fa-users-cog mr-3"></i> Todas as Participações</h1>
+
+    <?php if (empty($participacoes)): ?>
+        <p>Nenhuma participação encontrada.</p>
+    <?php else: ?>
+        <div class="overflow-x-auto">
+            <table class="min-w-full bg-white border border-gray-200">
+                <thead>
+                    <tr>
+                        <th class="py-2 px-4 border-b">ID</th>
+                        <th class="py-2 px-4 border-b">Campanha</th>
+                        <th class="py-2 px-4 border-b">Usuário</th>
+                        <th class="py-2 px-4 border-b">Data Participação</th>
+                        <th class="py-2 px-4 border-b">Status</th>
+                        <th class="py-2 px-4 border-b">Ações</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($participacoes as $participacao): ?>
+                        <tr>
+                            <td class="py-2 px-4 border-b text-center"><?php echo $participacao->id; ?></td>
+                            <td class="py-2 px-4 border-b"><?php echo $participacao->campanha_nome; ?></td>
+                            <td class="py-2 px-4 border-b"><?php echo $participacao->usuario_nome; ?></td>
+                            <td class="py-2 px-4 border-b text-center"><?php echo date('d/m/Y H:i', strtotime($participacao->data_participacao)); ?></td>
+                            <td class="py-2 px-4 border-b text-center"><?php echo ucfirst($participacao->status_participacao); ?></td>
+                            <td class="py-2 px-4 border-b text-center">
+                                <!-- AIDEV-TODO: Adicionar ações como editar status da participação, etc. -->
+                                <a href="#" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-2 rounded text-xs">Detalhes</a>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+</div>

--- a/application/views/participacoes/mobile_campanhas.php
+++ b/application/views/participacoes/mobile_campanhas.php
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Campanhas Disponíveis</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+    <style>
+        body { background-color: #f0f2f5; }
+        .mobile-frame { 
+            position: absolute; /* Alterado para absolute */
+            top: 100px; /* Ajustado para ficar abaixo da navbar */
+            left: 50%;
+            transform: translateX(-50%); /* Apenas centralização horizontal */
+            width: 375px; /* Largura de um iPhone X */
+            height: 600px; /* Altura reduzida */
+            border: 8px solid #333; 
+            border-radius: 20px; 
+            box-shadow: 0 0 15px rgba(0,0,0,0.2); 
+            overflow: hidden; 
+            background-color: white;
+        }
+        .mobile-header { background-color: #312e81; color: white; padding: 20px; text-align: center; font-size: 1.5rem; font-weight: bold; }
+        .content-scroll { height: calc(100% - 60px); overflow-y: auto; } /* Altura do frame menos a altura do header */
+        .campaign-card { border-bottom: 1px solid #e0e0e0; padding: 20px; margin-bottom: 15px; }
+        .campaign-card:last-child { border-bottom: none; }
+    </style>
+</head>
+<body class="font-sans antialiased bg-gray-50">
+    <div class="mobile-frame">
+        <div class="mobile-header">Campanhas Disponíveis</div>
+        <div class="p-5 content-scroll">
+            <!-- Card Campeão de Resgates -->
+            <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-yellow-500 mb-6">
+                <div class="flex items-center justify-between mb-4">
+                    <h2 class="text-lg font-semibold text-gray-700">🏆 Campeão de Resgates</h2>
+                    <div class="text-yellow-500 text-2xl"><i class="fas fa-trophy"></i></div>
+                </div>
+                <p class="text-xl font-bold text-gray-900">Funcionário: <?php echo ($campeao_nome == $current_user_name) ? '<span class="text-blue-600">' . $campeao_nome . ' (Você!)</span>' : $campeao_nome; ?></p>
+                <p class="text-xl font-bold text-gray-900 mb-2">Total Resgatado: R$ <?php echo number_format($campeao_resgatado, 2, ',', '.'); ?></p>
+                <p class="text-sm text-gray-600">Parabéns, <?php echo $campeao_nome; ?>! Você é o destaque do mês!</p>
+                <p class="text-sm text-gray-500">Continue participando das campanhas e você pode ser o próximo campeão!</p>
+            </div>
+
+            <?php if ($this->session->flashdata('success')): ?>
+                <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+                    <?php echo $this->session->flashdata('success'); ?>
+                </div>
+            <?php endif; ?>
+            <?php if ($this->session->flashdata('error')): ?>
+                <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+                    <?php echo $this->session->flashdata('error'); ?>
+                </div>
+            <?php endif; ?>
+
+            <?php if (empty($campanhas_disponiveis)): ?>
+                <p class="text-gray-600 text-center text-base">Nenhuma campanha disponível no momento.</p>
+            <?php else: ?>
+                <?php foreach ($campanhas_disponiveis as $campanha): ?>
+                    <div class="campaign-card bg-white rounded-lg shadow-md mb-6 p-6">
+                        <h2 class="text-xl font-extrabold text-gray-900 mb-2">🏆 <?php echo $campanha->nome; ?></h2>
+                        <p class="text-base text-gray-700 mb-3"><?php echo $campanha->descricao; ?></p>
+                        <p class="text-sm text-gray-600">De: <?php echo date('d/m/Y', strtotime($campanha->data_inicio)); ?> até: <?php echo date('d/m/Y', strtotime($campanha->data_fim)); ?></p>
+                        <p class="text-sm text-gray-600 mb-2">Recorrência: <?php echo ucfirst($campanha->recorrencia); ?></p>
+                        <p class="text-lg font-bold text-green-600 mb-4">💰 Prêmio: R$ <?php echo number_format($campanha->premio, 2, ',', '.'); ?></p>
+                        <a href="<?php echo site_url('participacoes/participar/' . $campanha->id); ?>" class="block w-full text-center bg-orange-500 hover:bg-orange-600 text-white font-extrabold py-3 px-6 rounded-xl transition duration-200 text-lg">Quero Participar</a>
+                    </div>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </div>
+    </div>
+</body>
+</html>

--- a/application/views/templates/header_view.php
+++ b/application/views/templates/header_view.php
@@ -41,6 +41,15 @@
                     <a href="<?php echo site_url('pagamentos'); ?>" class="block py-2.5 px-4 rounded transition duration-200 hover:bg-gray-700 hover:text-white flex items-center">
                         <i class="fas fa-dollar-sign mr-3"></i> <span class="menu-text">Pagamentos</span>
                     </a>
+                    <div class="block py-2.5 px-4 rounded transition duration-200 hover:bg-gray-700 hover:text-white flex items-center cursor-pointer">
+                        <i class="fas fa-users-cog mr-3"></i> <span class="menu-text">Participações</span>
+                    </div>
+                    <a href="<?php echo site_url('participacoes/ativas'); ?>" class="block py-2.5 pl-10 pr-4 rounded transition duration-200 hover:bg-gray-700 hover:text-white flex items-center text-sm">
+                        <i class="fas fa-chart-pie mr-3"></i> <span class="menu-text">Ativas (Cards)</span>
+                    </a>
+                    <a href="<?php echo site_url('participacoes'); ?>" class="block py-2.5 pl-10 pr-4 rounded transition duration-200 hover:bg-gray-700 hover:text-white flex items-center text-sm">
+                        <i class="fas fa-mobile-alt mr-3"></i> <span class="menu-text">Mobile (Simulador)</span>
+                    </a>
                     <a href="#" class="block py-2.5 px-4 rounded transition duration-200 hover:bg-gray-700 hover:text-white flex items-center">
                         <i class="fas fa-chart-line mr-3"></i> <span class="menu-text">Relatórios</span>
                     </a>


### PR DESCRIPTION
Foi desenvolvido o menu Participações com dois modos: cards visuais de campanhas ativas e simulador mobile com campanhas disponíveis. O visual foi aprimorado com botões em destaque, premiação, detalhes de recorrência e identificação do campeão do mês. Atualizações também refletem na dashboard. Estrutura modular pronta para novas interações com validações e resgates.

